### PR TITLE
Update rollupsContractsUrl to version 1.4.0

### DIFF
--- a/internal/contracts/generate/main.go
+++ b/internal/contracts/generate/main.go
@@ -27,12 +27,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
 
-// const rollupsContractsUrl
-// = "https://github.com/cartesi/rollups-contracts/archive/refs/tags/v1.2.0.tar.gz"
-// const baseContractsPath = "onchain/rollups/contracts/"
-
 const (
-	rollupsContractsUrl = "https://registry.npmjs.org/@cartesi/rollups/-/rollups-1.1.0.tgz"
+	rollupsContractsUrl = "https://registry.npmjs.org/@cartesi/rollups/-/rollups-1.4.0.tgz"
 	baseContractsPath   = "package/export/artifacts/contracts/"
 	bindingPkg          = "contracts"
 )


### PR DESCRIPTION
This pull request updates the rollupsContractsUrl to version 1.4.0, fixing a bug in the previous version.