### PR TITLE
Refactor: Rename ExpressoService to EspressoService

### DIFF
--- a/internal/dataavailability/espresso.go
+++ b/internal/dataavailability/espresso.go
@@ -147,7 +147,7 @@ func (e *EspressoFetcher) Fetch(ctx echo.Context, id string) (*string, *HttpCust
 
 	ctxHttp := ctx.Request().Context()
 	urlBase := "https://query.cappuccino.testnet.espresso.network/"
-	espressoService := NewExpressoService(ctxHttp, &urlBase)
+	espressoService := NewEspressoService(ctxHttp, &urlBase)
 
 	for {
 		lastEspressoBlockHeight, err := espressoService.GetLatestBlockHeight()

--- a/internal/dataavailability/espresso_api.go
+++ b/internal/dataavailability/espresso_api.go
@@ -18,19 +18,19 @@ type EspressoAPI interface {
 	GetBlockByHeight(height *big.Int) (*EspressoBlockResponse, error)
 }
 
-type ExpressoService struct {
+type EspressoService struct {
 	context context.Context
 	client  *client.Client
 }
 
-func NewExpressoService(ctx context.Context, url *string) *ExpressoService {
+func NewEspressoService(ctx context.Context, url *string) *EspressoService {
 	var myClient *client.Client
 
 	if url != nil {
 		myClient = client.NewClient(*url)
 	}
 
-	return &ExpressoService{
+	return &EspressoService{
 		context: ctx,
 		client:  myClient,
 	}
@@ -42,7 +42,7 @@ func NewExpressoService(ctx context.Context, url *string) *ExpressoService {
  * https://docs.espressosys.com/sequencer/api-reference/sequencer-api/status-api#get-status-block-height
  * returns integer
  */
-func (s *ExpressoService) GetLatestBlockHeight() (*big.Int, error) {
+func (s *EspressoService) GetLatestBlockHeight() (*big.Int, error) {
 	// This is a mock implementation
 	if s.client == nil {
 		mock := 32644
@@ -64,7 +64,7 @@ func (s *ExpressoService) GetLatestBlockHeight() (*big.Int, error) {
  * GET /availability/header/:height
  * https://docs.espressosys.com/sequencer/api-reference/sequencer-api/availability-api#get-availability-header
  */
-func (s *ExpressoService) GetHeaderByBlockByHeight(height *big.Int) (*EspressoHeader, error) {
+func (s *EspressoService) GetHeaderByBlockByHeight(height *big.Int) (*EspressoHeader, error) {
 	if s.client == nil {
 		mock := 32644
 
@@ -89,7 +89,7 @@ func (s *ExpressoService) GetHeaderByBlockByHeight(height *big.Int) (*EspressoHe
  * GET /availability/block/:height/namespace/:namespace
  * https://docs.espressosys.com/sequencer/api-reference/sequencer-api/availability-api#get-availability-block-height-namespace-namespace
  */
-func (s *ExpressoService) GetTransactionByHeight(height *big.Int) (*EspressoBlockResponse, error) {
+func (s *EspressoService) GetTransactionByHeight(height *big.Int) (*EspressoBlockResponse, error) {
 	if s.client == nil {
 		return &EspressoBlockResponse{
 			Transactions: nil,


### PR DESCRIPTION
This commit renames the `ExpressoService` struct to `EspressoService` in the `espresso.go` file. The typo in the struct name is corrected for consistency and clarity. This change improves the readability and maintainability of the codebase.