### PR TITLE
Refactor: Remove unused interface

### DIFF
--- a/internal/dataavailability/espresso_api.go
+++ b/internal/dataavailability/espresso_api.go
@@ -12,12 +12,6 @@ import (
 type EspressoHeader = types.Header
 type EspressoBlockResponse = client.TransactionsInBlock
 
-type EspressoAPI interface {
-	GetLatestBlockHeight() (*big.Int, error)
-	GetHeaderByBlockByHeight(height *big.Int) (*EspressoHeader, error)
-	GetBlockByHeight(height *big.Int) (*EspressoBlockResponse, error)
-}
-
 type EspressoService struct {
 	context context.Context
 	client  *client.Client


### PR DESCRIPTION
This pull request removes an unused interface from the codebase. The interface was not being used and can be safely removed. This change improves code cleanliness and reduces unnecessary complexity.