### PR TITLE
bugfix: simple deduplication

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -208,6 +208,6 @@ jobs:
         run: |
           npm ci
           npm pack
-          npm publish --access public --tag alpha
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,6 +60,7 @@
         "postgres",
         "Preparex",
         "Queryx",
+        "randao",
         "Randao",
         "readerclient",
         "rollup",

--- a/internal/model/input_repository.go
+++ b/internal/model/input_repository.go
@@ -120,8 +120,6 @@ func (r *InputRepository) FindByStatusNeDesc(status CompletionStatus) (*AdvanceI
 }
 
 func (r *InputRepository) FindByStatus(status CompletionStatus) (*AdvanceInput, error) {
-	slog.Debug("FindByStatus", "status", status)
-
 	sql := `SELECT
 		input_index,
 		status,


### PR DESCRIPTION
It just keeps the blob as a key for 2 blocks to see if the transaction is duplicated.

Publish brunodo as latest on npm