### PR TITLE
Espresso eip712

### DIFF
--- a/internal/sequencers/espresso/espresso_listener.go
+++ b/internal/sequencers/espresso/espresso_listener.go
@@ -12,8 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const DEDUPLICATION_BLOCKS = 3
-
 type EspressoListener struct {
 	espressoAPI     *dataavailability.EspressoAPI
 	namespace       uint64
@@ -49,10 +47,9 @@ func (e EspressoListener) watchNewTransactions(ctx context.Context) error {
 	slog.Debug("Espresso: watchNewTransactions", "fromBlock", e.fromBlock)
 	currentBlockHeight := e.fromBlock
 
-	mapToDeduplicate := make([]map[string]bool, DEDUPLICATION_BLOCKS)
-	for i := range mapToDeduplicate {
-		mapToDeduplicate[i] = make(map[string]bool)
-	}
+	// keep track of msgSender -> nonce
+	nonceMap := make(map[common.Address]int64)
+
 	// main polling loop
 	for {
 		slog.Debug("Espresso: fetchLatestBlockHeight...")
@@ -67,9 +64,6 @@ func (e EspressoListener) watchNewTransactions(ctx context.Context) error {
 			continue
 		}
 		for ; currentBlockHeight < lastEspressoBlockHeight; currentBlockHeight++ {
-			iMap := currentBlockHeight % DEDUPLICATION_BLOCKS
-			dMap := (currentBlockHeight + DEDUPLICATION_BLOCKS - 1) % DEDUPLICATION_BLOCKS
-			mapToDeduplicate[dMap] = make(map[string]bool)
 			slog.Debug("Espresso:", "currentBlockHeight", currentBlockHeight)
 			transactions, err := e.espressoAPI.FetchTransactionsInBlock(ctx, currentBlockHeight, e.namespace)
 			if err != nil {
@@ -78,16 +72,9 @@ func (e EspressoListener) watchNewTransactions(ctx context.Context) error {
 			tot := len(transactions.Transactions)
 			slog.Debug("Espresso:", "transactionsLen", tot)
 			for i := 0; i < tot; i++ {
-				nextBlock := (iMap + 1) % DEDUPLICATION_BLOCKS
 				transaction := transactions.Transactions[i]
-				key := common.Bytes2Hex(transaction)
-				slog.Debug("transaction", "currentBlockHeight", currentBlockHeight, "transaction", key)
-				if mapToDeduplicate[iMap][key] || mapToDeduplicate[nextBlock][key] {
-					slog.Debug("Espresso: duplicated", "transaction", transaction)
-					continue
-				}
-				slog.Debug("not duplicated")
-				mapToDeduplicate[nextBlock][key] = true
+				slog.Debug("transaction", "currentBlockHeight", currentBlockHeight, "transaction", transaction)
+
 				// transform and add to InputRepository
 				index, err := e.InputRepository.Count(nil)
 				if err != nil {
@@ -103,18 +90,30 @@ func (e EspressoListener) watchNewTransactions(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
-				fmt.Println(msgSender)
+				fmt.Println("msg sender ", msgSender.String())
 				// type EspressoMessage struct {
 				// 	nonce   uint32 `json:"nonce"`
 				// 	payload string `json:"payload"`
 				// }
-				nonce, ok1 := typedData.Message["nonce"].(uint32)
-				payload, ok2 := typedData.Message["payload"].(string)
-				if !ok1 || !ok2 {
+				nonce := int64(typedData.Message["nonce"].(float64)) // by default, JSON number is float64
+				payload, ok := typedData.Message["payload"].(string)
+				if !ok {
 					slog.Debug("type assertion error ")
 				}
 				fmt.Println("nonce ", nonce)
 				fmt.Println("payload ", payload)
+
+				// update nonce maps
+				// no need to consider node exits abruptly and restarts from where it left
+				// app has to start `nonce` from 1 and increment by 1 for each payload
+				if nonceMap[msgSender] == nonce-1 {
+					nonceMap[msgSender] = nonce
+					// fmt.Println("nonce is now ", nonce)
+				} else {
+					// nonce repeated
+					fmt.Println("duplicated or incorrect nonce")
+					continue
+				}
 
 				_, err = e.InputRepository.Create(model.AdvanceInput{
 					Index:       int(index),

--- a/internal/sequencers/espresso/espresso_listener.go
+++ b/internal/sequencers/espresso/espresso_listener.go
@@ -97,11 +97,11 @@ func (e EspressoListener) watchNewTransactions(ctx context.Context) error {
 				// }
 				nonce := int64(typedData.Message["nonce"].(float64)) // by default, JSON number is float64
 				payload, ok := typedData.Message["payload"].(string)
-				if !ok {
-					slog.Debug("type assertion error ")
-				}
 				fmt.Println("nonce ", nonce)
 				fmt.Println("payload ", payload)
+				if !ok {
+					return fmt.Errorf("type assertion error")
+				}
 
 				// update nonce maps
 				// no need to consider node exits abruptly and restarts from where it left

--- a/internal/sequencers/espresso/extract.go
+++ b/internal/sequencers/espresso/extract.go
@@ -1,0 +1,61 @@
+package espresso
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+)
+
+type SigAndData struct {
+	Signature string `json:"signature"`
+	TypedData string `json:"typedData"`
+}
+
+func ExtractSigAndData(raw string) (common.Address, apitypes.TypedData, error) {
+	var sigAndData SigAndData
+	if err := json.Unmarshal([]byte(raw), &sigAndData); err != nil {
+		return common.HexToAddress("0x"), apitypes.TypedData{}, fmt.Errorf("unmarshal sigAndData: %w", err)
+	}
+
+	signature, err := hexutil.Decode(sigAndData.Signature)
+	if err != nil {
+		return common.HexToAddress("0x"), apitypes.TypedData{}, fmt.Errorf("decode signature: %w", err)
+	}
+
+	typedDataBytes, err := base64.StdEncoding.DecodeString(sigAndData.TypedData)
+	if err != nil {
+		return common.HexToAddress("0x"), apitypes.TypedData{}, fmt.Errorf("decode typed data: %w", err)
+	}
+
+	typedData := apitypes.TypedData{}
+	if err := json.Unmarshal(typedDataBytes, &typedData); err != nil {
+		return common.HexToAddress("0x"), apitypes.TypedData{}, fmt.Errorf("unmarshal typed data: %w", err)
+	}
+
+	dataHash, _, err := apitypes.TypedDataAndHash(typedData)
+	if err != nil {
+		return common.HexToAddress("0x"), apitypes.TypedData{}, fmt.Errorf("typed data hash: %w", err)
+	}
+
+	// update the recovery id
+	// https://github.com/ethereum/go-ethereum/blob/55599ee95d4151a2502465e0afc7c47bd1acba77/internal/ethapi/api.go#L442
+	signature[64] -= 27
+
+	// get the pubkey used to sign this signature
+	sigPubkey, err := crypto.Ecrecover(dataHash, signature)
+	if err != nil {
+		return common.HexToAddress("0x"), apitypes.TypedData{}, fmt.Errorf("ecrecover: %w", err)
+	}
+	pubkey, err := crypto.UnmarshalPubkey(sigPubkey)
+	if err != nil {
+		return common.HexToAddress("0x"), apitypes.TypedData{}, fmt.Errorf("unmarshal: %w", err)
+	}
+	address := crypto.PubkeyToAddress(*pubkey)
+
+	return address, typedData, nil
+}


### PR DESCRIPTION
currently, this branch is able to extract the eip712 signer address, and the signed data (which includes `nonce` and `payload`)

This branch is a work in progress and the to-dos include:
- [x] only accept `nonce` that is incremental by 1 from the account's previous nonce in the database
- [ ] if users query for a nonce, generate a report?
- [ ] review and optimize frontend backend encoding schemes
- [ ] figure out what's the best UX for users to submit to espresso