### PR TITLE
Refactor inspectAPI and add timeout values

### DIFF
--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -28,7 +28,7 @@ type Model interface {
 
 // Register the rollup API to echo
 func Register(e *echo.Echo, model Model) {
-	inspectAPI := &inspectAPI{model}
+	var inspectAPI ServerInterface = &inspectAPI{model}
 	RegisterHandlers(e, inspectAPI)
 }
 
@@ -39,7 +39,9 @@ type inspectAPI struct {
 
 // Handle POST requests to /.
 func (a *inspectAPI) InspectPost(c echo.Context) error {
-	payload, err := io.ReadAll(c.Request().Body)
+	body := c.Request().Body
+	defer body.Close()
+	payload, err := io.ReadAll(body)
 	if err != nil {
 		return c.String(http.StatusBadRequest, err.Error())
 	}

--- a/internal/nonodo/nonodo.go
+++ b/internal/nonodo/nonodo.go
@@ -31,7 +31,6 @@ import (
 
 const DefaultHttpPort = 8080
 const DefaultRollupsPort = 5004
-const HttpTimeout = 10 * time.Second
 
 // Options to nonodo.
 type NonodoOpts struct {
@@ -69,10 +68,14 @@ type NonodoOpts struct {
 
 	// If set, enables legacy mode.
 	LegacyMode bool
+
+	TimeoutInspect time.Duration
+	TimeoutAdvance time.Duration
 }
 
 // Create the options struct with default values.
 func NewNonodoOpts() NonodoOpts {
+	var defaultTimeout time.Duration = 10 * time.Second
 	return NonodoOpts{
 		AnvilAddress:       devnet.AnvilDefaultAddress,
 		AnvilPort:          devnet.AnvilDefaultPort,
@@ -93,6 +96,8 @@ func NewNonodoOpts() NonodoOpts {
 		FromBlock:          0,
 		DbImplementation:   "sqlite",
 		LegacyMode:         true,
+		TimeoutInspect:     defaultTimeout,
+		TimeoutAdvance:     defaultTimeout,
 	}
 }
 
@@ -141,7 +146,7 @@ func NewSupervisorPoC(opts NonodoOpts) supervisor.SupervisorWorker {
 	e.Use(middleware.Recover())
 	e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
 		ErrorMessage: "Request timed out",
-		Timeout:      HttpTimeout,
+		Timeout:      opts.TimeoutInspect,
 	}))
 	inspect.Register(e, model)
 	reader.Register(e, model, convenienceService, adapter)
@@ -167,7 +172,7 @@ func NewSupervisor(opts NonodoOpts) supervisor.SupervisorWorker {
 	e.Use(middleware.Recover())
 	e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
 		ErrorMessage: "Request timed out",
-		Timeout:      HttpTimeout,
+		Timeout:      opts.TimeoutInspect,
 	}))
 	inspect.Register(e, model)
 	reader.Register(e, model, convenienceService, adapter)
@@ -178,7 +183,7 @@ func NewSupervisor(opts NonodoOpts) supervisor.SupervisorWorker {
 	re.Use(middleware.Recover())
 	re.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{
 		ErrorMessage: "Request timed out",
-		Timeout:      HttpTimeout,
+		Timeout:      opts.TimeoutAdvance,
 	}))
 
 	if opts.LegacyMode {

--- a/main.go
+++ b/main.go
@@ -77,6 +77,8 @@ func init() {
 		"enable-legacy",
 		opts.LegacyMode,
 		"If set, enables legacy based in 0.7.1 (branch 0.7.3) rollups interface")
+	cmd.Flags().DurationVar(&opts.TimeoutInspect, "enable-timeout-inspect", opts.TimeoutInspect, "Timeout for inspect requests")
+	cmd.Flags().DurationVar(&opts.TimeoutAdvance, "enable-timeout-advance", opts.TimeoutAdvance, "Timeout for advance requests")
 
 	// disable-*
 	cmd.Flags().BoolVar(&opts.DisableDevnet, "disable-devnet", opts.DisableDevnet,


### PR DESCRIPTION
This pull request includes refactoring of the inspectAPI struct and the addition of timeout values for inspect and advance requests. The inspectAPI struct has been updated to use the ServerInterface type. Additionally, the NonodoOpts struct now includes TimeoutInspect and TimeoutAdvance fields, which allow for specifying custom timeout values for inspect and advance requests. This improves the flexibility and control of the application's request handling.