### PR TITLE
Update rollup.yaml version to '0.9.0'

### DIFF
--- a/api/generate/main.go
+++ b/api/generate/main.go
@@ -38,7 +38,7 @@ func getYAML(v2 string) []byte {
 
 func main() {
 	// v2URL := "https://raw.githubusercontent.com/cartesi/openapi-interfaces/v0.8.0/rollup.yaml"
-	v2URL := "https://raw.githubusercontent.com/cartesi/openapi-interfaces/fix/http-server/rollup.yaml"
+	v2URL := "https://raw.githubusercontent.com/cartesi/openapi-interfaces/b0209b2203c823a1648330236a7a211d720d48bd/rollup.yaml"
 	inspectURL := "https://raw.githubusercontent.com/cartesi/rollups-node/v1.4.0/api/openapi/inspect.yaml"
 
 	v2 := getYAML(v2URL)

--- a/api/rollup.yaml
+++ b/api/rollup.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 
 info:
   title: Cartesi Rollup HTTP API
-  version: 0.8.1
+  version: '0.9.0'
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
This pull request updates the rollup.yaml file to version '0.9.0'. The previous version was '0.8.1'.