### PR TITLE
feat: flag to disable the sync from graphile

### DIFF
--- a/DEV2DEV.md
+++ b/DEV2DEV.md
@@ -38,3 +38,23 @@ Run the nonodo with HL GraphQL flag enabled
 ```
 ./nonodo --high-level-graphql --enable-debug --node-version v2
 ```
+
+```
+export POSTGRES_HOST=127.0.0.1
+export POSTGRES_PORT=5432
+export POSTGRES_DB=mydatabase
+export POSTGRES_USER=myuser
+export POSTGRES_PASSWORD=mypassword
+./nonodo --http-address=0.0.0.0 --high-level-graphql --enable-debug --node-version v2 --load-test-mode --db-implementation postgres
+```
+
+Disable sync
+
+```
+export POSTGRES_HOST=127.0.0.1
+export POSTGRES_PORT=5432
+export POSTGRES_DB=mydatabase
+export POSTGRES_USER=myuser
+export POSTGRES_PASSWORD=mypassword
+./nonodo --http-address=0.0.0.0 --high-level-graphql --enable-debug --node-version v2 --db-implementation postgres --graphile-disable-sync
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ RUN go build -o nonodo
 EXPOSE 8080
 
 # Comando para rodar a aplicação
-CMD ["./nonodo", "--http-address=0.0.0.0", "--high-level-graphql", "--enable-debug", "--node-version", "v2", "--load-test-mode", "--db-implementation", "postgres"]
+CMD ["./nonodo", "--http-address=0.0.0.0", "--high-level-graphql", "--enable-debug", "--node-version", "v2", "--db-implementation", "postgres", "--graphile-address", "postgraphile-custom"]

--- a/internal/convenience/container.go
+++ b/internal/convenience/container.go
@@ -1,6 +1,8 @@
 package convenience
 
 import (
+	"log/slog"
+
 	"github.com/calindra/nonodo/internal/convenience/decoder"
 	"github.com/calindra/nonodo/internal/convenience/repository"
 	"github.com/calindra/nonodo/internal/convenience/services"
@@ -175,7 +177,10 @@ func (c *Container) GetGraphileClient(graphileAddress string, graphilePort strin
 	if loadTestMode {
 		graphileAddress = "postgraphile-custom"
 	}
-
+	slog.Debug("GraphileClient",
+		"graphileAddress", graphileAddress,
+		"graphilePort", graphilePort,
+	)
 	c.graphileClient = &graphile.GraphileClientImpl{
 		GraphileAddress: graphileAddress,
 		GraphilePort:    graphilePort,

--- a/internal/nonodo/nonodo.go
+++ b/internal/nonodo/nonodo.go
@@ -77,40 +77,42 @@ type NonodoOpts struct {
 	TimeoutInspect time.Duration
 	TimeoutAdvance time.Duration
 
-	GraphileAddress string
-	GraphilePort    string
+	GraphileAddress     string
+	GraphilePort        string
+	GraphileDisableSync bool
 }
 
 // Create the options struct with default values.
 func NewNonodoOpts() NonodoOpts {
 	var defaultTimeout time.Duration = 10 * time.Second
 	return NonodoOpts{
-		AnvilAddress:       devnet.AnvilDefaultAddress,
-		AnvilPort:          devnet.AnvilDefaultPort,
-		AnvilVerbose:       false,
-		HttpAddress:        "127.0.0.1",
-		HttpPort:           DefaultHttpPort,
-		HttpRollupsPort:    DefaultRollupsPort,
-		InputBoxAddress:    devnet.InputBoxAddress,
-		InputBoxBlock:      0,
-		ApplicationAddress: devnet.ApplicationAddress,
-		RpcUrl:             "",
-		EnableEcho:         false,
-		DisableDevnet:      false,
-		DisableAdvance:     false,
-		ApplicationArgs:    nil,
-		HLGraphQL:          false,
-		SqliteFile:         "file:memory1?mode=memory&cache=shared",
-		FromBlock:          0,
-		DbImplementation:   "sqlite",
-		NodeVersion:        "v1",
-		Sequencer:          "inputbox",
-		LoadTestMode:       false,
-		Namespace:          DefaultNamespace,
-		TimeoutInspect:     defaultTimeout,
-		TimeoutAdvance:     defaultTimeout,
-		GraphileAddress:    "localhost",
-		GraphilePort:       "5000",
+		AnvilAddress:        devnet.AnvilDefaultAddress,
+		AnvilPort:           devnet.AnvilDefaultPort,
+		AnvilVerbose:        false,
+		HttpAddress:         "127.0.0.1",
+		HttpPort:            DefaultHttpPort,
+		HttpRollupsPort:     DefaultRollupsPort,
+		InputBoxAddress:     devnet.InputBoxAddress,
+		InputBoxBlock:       0,
+		ApplicationAddress:  devnet.ApplicationAddress,
+		RpcUrl:              "",
+		EnableEcho:          false,
+		DisableDevnet:       false,
+		DisableAdvance:      false,
+		ApplicationArgs:     nil,
+		HLGraphQL:           false,
+		SqliteFile:          "file:memory1?mode=memory&cache=shared",
+		FromBlock:           0,
+		DbImplementation:    "sqlite",
+		NodeVersion:         "v1",
+		Sequencer:           "inputbox",
+		LoadTestMode:        false,
+		Namespace:           DefaultNamespace,
+		TimeoutInspect:      defaultTimeout,
+		TimeoutAdvance:      defaultTimeout,
+		GraphileAddress:     "localhost",
+		GraphilePort:        "5000",
+		GraphileDisableSync: false,
 	}
 }
 
@@ -152,7 +154,17 @@ func NewSupervisorHLGraphQL(opts NonodoOpts) supervisor.SupervisorWorker {
 		adapter = reader.NewAdapterV2(convenienceService, httpClient, inputBlobAdapter)
 	}
 
-	if !opts.LoadTestMode {
+	if opts.RpcUrl == "" && !opts.DisableDevnet {
+		w.Workers = append(w.Workers, devnet.AnvilWorker{
+			Address: opts.AnvilAddress,
+			Port:    opts.AnvilPort,
+			Verbose: opts.AnvilVerbose,
+		})
+		opts.RpcUrl = fmt.Sprintf("ws://%s:%v", opts.AnvilAddress, opts.AnvilPort)
+	}
+
+	if !opts.LoadTestMode && !opts.GraphileDisableSync {
+		slog.Debug("Sync initialization")
 		var synchronizer supervisor.Worker
 
 		if opts.NodeVersion == "v2" {

--- a/main.go
+++ b/main.go
@@ -431,6 +431,9 @@ func init() {
 	cmd.Flags().BoolVar(&opts.LoadTestMode, "load-test-mode", opts.LoadTestMode,
 		"If set, enables load test mode")
 
+	cmd.Flags().BoolVar(&opts.GraphileDisableSync, "graphile-disable-sync", opts.GraphileDisableSync,
+		"If set, disable graphile synchronization")
+
 	cmd.Flags().StringVar(&opts.GraphileAddress, "graphile-address", opts.GraphileAddress,
 		"Address used to connect to Graphile")
 


### PR DESCRIPTION
Run the postgraphile

```bash
docker network create mynetwork
docker build -t postgresteste:latest ./postgres
docker run -d --network mynetwork -p 5432:5432 --name postgres postgresteste:latest

docker build -t postgraphile-custom ./postgraphile/
docker run -d --network mynetwork -p 5000:5000 --name postgraphile-custom postgraphile-custom
```

Build nonodo

```bash
go build
```

Check if the graphile-disable-sync flag is working

```bash
export POSTGRES_HOST=127.0.0.1
export POSTGRES_PORT=5432
export POSTGRES_DB=mydatabase
export POSTGRES_USER=myuser
export POSTGRES_PASSWORD=mypassword
./nonodo --http-address=0.0.0.0 --high-level-graphql --enable-debug --node-version v2 --db-implementation postgres --graphile-disable-sync
```