### PR TITLE
feat: report idempotency

### DIFF
--- a/DEV2DEV.md
+++ b/DEV2DEV.md
@@ -22,7 +22,7 @@ Input encoded by rollups-contract V2
 
 Run the postgraphile
 
-```
+```bash
 docker network create mynetwork
 docker build -t postgresteste:latest ./postgres
 docker run -d --network mynetwork -p 5432:5432 --name postgres postgresteste:latest
@@ -45,7 +45,7 @@ export POSTGRES_PORT=5432
 export POSTGRES_DB=mydatabase
 export POSTGRES_USER=myuser
 export POSTGRES_PASSWORD=mypassword
-./nonodo --http-address=0.0.0.0 --high-level-graphql --enable-debug --node-version v2 --load-test-mode --db-implementation postgres
+./nonodo --http-address=0.0.0.0 --high-level-graphql --enable-debug --node-version v2 --db-implementation postgres
 ```
 
 Disable sync

--- a/internal/convenience/repository/report_repository.go
+++ b/internal/convenience/repository/report_repository.go
@@ -57,6 +57,23 @@ func (r *ReportRepository) Create(ctx context.Context, report cModel.Report) (cM
 	return report, nil
 }
 
+func (r *ReportRepository) Update(ctx context.Context, report cModel.Report) (*cModel.Report, error) {
+	sql := `UPDATE convenience_reports
+		SET payload = $1
+		WHERE input_index = $2 and output_index = $3 `
+	_, err := r.Db.ExecContext(
+		ctx,
+		sql,
+		common.Bytes2Hex(report.Payload),
+		report.InputIndex,
+		report.Index,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
 func (r *ReportRepository) FindByInputAndOutputIndex(
 	ctx context.Context,
 	inputIndex uint64,

--- a/internal/convenience/synchronizer/graphile_synchornizer.go
+++ b/internal/convenience/synchronizer/graphile_synchornizer.go
@@ -139,7 +139,7 @@ func (x GraphileSynchronizer) handleGraphileResponse(outputResp OutputResponse, 
 	}
 
 	for _, report := range outputResp.Data.Reports.Edges {
-		slog.Debug("Add Report",
+		slog.Debug("Call HandleReport",
 			"Index", report.Node.Index,
 			"InputIndex", report.Node.InputIndex,
 		)
@@ -167,7 +167,7 @@ func (x GraphileSynchronizer) handleGraphileResponse(outputResp OutputResponse, 
 		x.GraphileFetcher.CursorInputAfter = outputResp.Data.Inputs.PageInfo.EndCursor
 	}
 
-	if hasMoreInputs || hasMoreOutputs {
+	if hasMoreInputs || hasMoreOutputs || hasMoreReports {
 		_, err := x.SynchronizerRepository.Create(
 			ctx, &model.SynchronizerFetch{
 				TimestampAfter:       uint64(time.Now().UnixMilli()),


### PR DESCRIPTION
# How to verify

Run the postgraphile

```bash
docker network create mynetwork
docker build -t postgresteste:latest ./postgres
docker run -d --network mynetwork -p 5432:5432 --name postgres postgresteste:latest

docker build -t postgraphile-custom ./postgraphile/
docker run -d --network mynetwork -p 5000:5000 --name postgraphile-custom postgraphile-custom
```

Build

```bash
go build
```

Run

```bash
export POSTGRES_HOST=127.0.0.1
export POSTGRES_PORT=5432
export POSTGRES_DB=mydatabase
export POSTGRES_USER=myuser
export POSTGRES_PASSWORD=mypassword
./nonodo --http-address=0.0.0.0 --high-level-graphql --enable-debug --node-version v2 --db-implementation postgres
```

Output:
```bash
[10:28:15.067] INF nonodo/nonodo.go:125 Using PostGres DB ...
[10:28:15.125] DBG repository/input_repository.go:46 Inputs table created
[10:28:15.126] DBG repository/report_repository.go:28 Reports table created
[10:28:15.126] DBG convenience/container.go:180 GraphileClient graphileAddress=localhost graphilePort=5000
[10:28:15.126] DBG reader/adapter_v2.go:61 NewAdapterV2
[10:28:15.126] DBG nonodo/nonodo.go:167 Sync initialization
[10:28:15.127] INF nonodo/nonodo.go:209 Listening port=8080
[10:28:15.128] DBG devnet/anvil.go:89 anvil: created temp dir with state file dir=/var/folders/rv/2kdnzvbj5y77c02fpxk6hnsh0000gn/T/573011767
[10:28:15.219] DBG supervisor/supervisor.go:60 supervisor: worker is ready worker=anvil
[10:28:15.219] DBG supervisor/supervisor.go:60 supervisor: worker is ready worker=GraphileSynchronizer
[10:28:15.219] INF convenience/voucher_exec_listener.go:83 Connecting to provider=ws://127.0.0.1:8545
[10:28:15.222] DBG supervisor/supervisor.go:60 supervisor: worker is ready worker=ExecListener
[10:28:15.223] DBG supervisor/supervisor.go:60 supervisor: worker is ready worker=http

Http Rollups for development started at http://localhost:5004
GraphQL running at http://localhost:8080/graphql
Inspect running at http://localhost:8080/inspect/
Press Ctrl+C to stop the node

[10:28:15.223] INF nonodo/main.go:492 nonodo: ready after=156.279375ms
[10:28:15.223] DBG convenience/voucher_exec_listener.go:93 ReadPastExecutions FromBlock=0
[10:28:15.225] DBG synchronizer/graphile_fetcher.go:210 Graphile querying afterOutput="" afterInput="WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=" afterReport=""
[10:28:15.228] INF convenience/voucher_exec_listener.go:145 Listening for execution events...
[10:28:15.280] DBG synchronizer/graphile_synchornizer.go:142 Call HandleReport Index=1 InputIndex=1
[10:28:15.282] DBG services/service.go:107 Report exist inputIndex=1 outputIndex=1
[10:28:15.287] DBG synchronizer/graphile_synchornizer.go:142 Call HandleReport Index=2 InputIndex=2
[10:28:15.288] DBG services/service.go:107 Report exist inputIndex=2 outputIndex=2
[10:28:18.293] DBG synchronizer/graphile_fetcher.go:210 Graphile querying afterOutput="" afterInput="WyJwcmltYXJ5X2tleV9hc2MiLFsyXV0=" afterReport="WyJwcmltYXJ5X2tleV9hc2MiLFsyLDJdXQ=="
```

You will see `Report exist inputIndex=2 outputIndex=2`