### PR TITLE
alter input index

### DIFF
--- a/internal/convenience/repository/input_repository.go
+++ b/internal/convenience/repository/input_repository.go
@@ -66,6 +66,10 @@ func (r *InputRepository) CreateTables() error {
 }
 
 func (r *InputRepository) Create(ctx context.Context, input model.AdvanceInput) (*model.AdvanceInput, error) {
+	// may twist the input index
+	count, _ := r.Count(ctx, nil)
+	input.Index = int(count)
+
 	exist, err := r.FindByIndex(ctx, input.Index)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
currently what I did is to set input index as the order that input was added into the database. So that index is not necessarily the same as the index in events for L1 inputs.
But this is something that we are still under discussions.