### PR TITLE
175-fix-graphile-url-environment

### DIFF
--- a/DEV2DEV.md
+++ b/DEV2DEV.md
@@ -71,5 +71,5 @@ go run . --http-address=0.0.0.0 --high-level-graphql --enable-debug --node-versi
 To configure the endpoint of the node v2 Graphile, you can set the `GRAPHILE_URL` environment variable. Here's how you can do it:
 
 ```bash
-export GRAPHILE_URL=localhost:5001
+export GRAPHILE_URL=localhost:5001/graphql
 ```

--- a/DEV2DEV.md
+++ b/DEV2DEV.md
@@ -22,8 +22,14 @@ Input encoded by rollups-contract V2
 
 Run the postgraphile
 
-```bash
+```shell
 docker compose up --wait up postgraphile
+```
+
+Stop with clean:
+
+```shell
+docker compose down --rmi local --remove-orphans --volumes
 ```
 
 [http://localhost:5001/graphiql](http://localhost:5001/graphiql)

--- a/DEV2DEV.md
+++ b/DEV2DEV.md
@@ -73,8 +73,9 @@ docker compose -f docker-compose.dev.yml up
 
 ## Environment Variables
 
-To configure the endpoint of the node v2 Graphile, you can set the GRAPHILE_URL environment variable. Here's how you can do it:
+To configure the endpoint of the node v2 Graphile, you can set the `GRAPHILE_HOST` and `GRAPHILE_PORT` environment variable. Here's how you can do it:
 
 ```bash
-export GRAPHILE_URL=http://localhost:5001/graphql
+export GRAPHILE_HOST=localhost
+export GRAPHILE_PORT=5001
 ```

--- a/DEV2DEV.md
+++ b/DEV2DEV.md
@@ -73,9 +73,8 @@ docker compose -f docker-compose.dev.yml up
 
 ## Environment Variables
 
-To configure the endpoint of the node v2 Graphile, you can set the `GRAPHILE_HOST` and `GRAPHILE_PORT` environment variable. Here's how you can do it:
+To configure the endpoint of the node v2 Graphile, you can set the `GRAPHILE_URL` environment variable. Here's how you can do it:
 
 ```bash
-export GRAPHILE_HOST=localhost
-export GRAPHILE_PORT=5001
+export GRAPHILE_URL=localhost:5001
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ EXPOSE 8080
 HEALTHCHECK CMD curl --fail http://localhost:8080/health || exit 1
 
 # Comando para rodar a aplicação
-CMD ["./nonodo", "--http-address=0.0.0.0", "--high-level-graphql", "--enable-debug", "--node-version", "v2", "--db-implementation", "postgres", "--graphile-address", "postgraphile", "--anvil-address", "0.0.0.0" ]
+CMD ["./nonodo", "--http-address=0.0.0.0", "--high-level-graphql", "--enable-debug", "--node-version", "v2", "--db-implementation", "postgres", "--graphile-url", "http://postgraphile:5001/graphql", "--anvil-address", "0.0.0.0" ]

--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ When running nonodo, set flag db-implementation with the value postgres
 
 Graphile can be called using `http://localhost:5001/graphql` and you can test queries using `http://localhost:5001/graphiql`
 
-You can change Graphile address and port using the flags graphile-address and graphile-port.
+You can change Graphile address and port using the flags graphile-url.
 
 ```sh
-/nonodo --graphile-address mygraphileaddress --graphile-port 5034
+/nonodo --graphile-url http://mygraphileaddress:5034
 ```
 
 ## Compatibility

--- a/internal/convenience/container.go
+++ b/internal/convenience/container.go
@@ -1,7 +1,9 @@
 package convenience
 
 import (
+	"fmt"
 	"log/slog"
+	"net/url"
 
 	"github.com/calindra/nonodo/internal/convenience/decoder"
 	"github.com/calindra/nonodo/internal/convenience/repository"
@@ -146,12 +148,12 @@ func (c *Container) GetVoucherFetcher() *synchronizer.VoucherFetcher {
 	return c.voucherFetcher
 }
 
-func (c *Container) GetGraphileSynchronizer(graphileAddress string, graphilePort string, loadTestMode bool) *synchronizer.GraphileSynchronizer {
+func (c *Container) GetGraphileSynchronizer(graphileUrl url.URL, loadTestMode bool) *synchronizer.GraphileSynchronizer {
 	if c.graphileSynchronizer != nil {
 		return c.graphileSynchronizer
 	}
 
-	graphileClient := c.GetGraphileClient(graphileAddress, graphilePort, loadTestMode)
+	graphileClient := c.GetGraphileClient(graphileUrl, loadTestMode)
 	c.graphileSynchronizer = synchronizer.NewGraphileSynchronizer(
 		c.GetOutputDecoder(),
 		c.GetSyncRepository(),
@@ -168,22 +170,20 @@ func (c *Container) GetGraphileFetcher(graphileClient graphile.GraphileClient) *
 	return c.graphileFetcher
 }
 
-func (c *Container) GetGraphileClient(graphileAddress string, graphilePort string, loadTestMode bool) graphile.GraphileClient {
+func (c *Container) GetGraphileClient(graphileUrl url.URL, loadTestMode bool) graphile.GraphileClient {
 
 	if c.graphileClient != nil {
 		return c.graphileClient
 	}
 
 	if loadTestMode {
-		graphileAddress = "postgraphile"
+		graphileUrl.Host = fmt.Sprintf("%s:%s", graphileUrl.Host, graphileUrl.Port())
 	}
 	slog.Debug("GraphileClient",
-		"graphileAddress", graphileAddress,
-		"graphilePort", graphilePort,
+		"graphileUrl", graphileUrl,
 	)
 	c.graphileClient = &graphile.GraphileClientImpl{
-		GraphileAddress: graphileAddress,
-		GraphilePort:    graphilePort,
+		GraphileUrl: graphileUrl,
 	}
 	return c.graphileClient
 }

--- a/internal/convenience/container.go
+++ b/internal/convenience/container.go
@@ -177,7 +177,12 @@ func (c *Container) GetGraphileClient(graphileUrl url.URL, loadTestMode bool) gr
 	}
 
 	if loadTestMode {
-		graphileUrl.Host = fmt.Sprintf("%s:%s", graphileUrl.Host, graphileUrl.Port())
+		const serviceName = "http://postgraphile"
+		if graphileUrl.Port() != "" {
+			graphileUrl.Host = fmt.Sprintf("%s:%s", serviceName, graphileUrl.Port())
+		} else {
+			graphileUrl.Host = serviceName
+		}
 	}
 	slog.Debug("GraphileClient",
 		"graphileUrl", graphileUrl,

--- a/internal/graphile/graphileclient_impl.go
+++ b/internal/graphile/graphileclient_impl.go
@@ -2,19 +2,18 @@ package graphile
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 )
 
 type GraphileClientImpl struct {
-	GraphileAddress string
-	GraphilePort    string
+	GraphileUrl url.URL
 }
 
 func (c *GraphileClientImpl) Post(requestBody []byte) ([]byte, error) {
-	req, err := http.NewRequest("POST", fmt.Sprintf("http://%s:%s/graphql", c.GraphileAddress, c.GraphilePort), bytes.NewBuffer(requestBody))
+	req, err := http.NewRequest("POST", c.GraphileUrl.String(), bytes.NewBuffer(requestBody))
 	if err != nil {
 		slog.Error("Error creating request", "error", err)
 		return nil, err

--- a/internal/nonodo/nonodo.go
+++ b/internal/nonodo/nonodo.go
@@ -92,7 +92,7 @@ func NewNonodoOpts() NonodoOpts {
 		defaultTimeout time.Duration = 10 * time.Second
 		graphileUrl                  = os.Getenv("GRAPHILE_URL")
 	)
-	const defaultGraphileUrl = "http://localhost:5001"
+	const defaultGraphileUrl = "http://localhost:5001/graphql"
 
 	if graphileUrl == "" {
 		graphileUrl = defaultGraphileUrl

--- a/internal/nonodo/nonodo.go
+++ b/internal/nonodo/nonodo.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"net/url"
 	"os"
 	"time"
 
@@ -81,24 +82,27 @@ type NonodoOpts struct {
 	TimeoutInspect time.Duration
 	TimeoutAdvance time.Duration
 
-	GraphileAddress     string
-	GraphilePort        string
+	GraphileUrl         string
 	GraphileDisableSync bool
 }
 
 // Create the options struct with default values.
 func NewNonodoOpts() NonodoOpts {
 	var (
-		defaultTimeout  time.Duration = 10 * time.Second
-		graphilePort    string        = os.Getenv("GRAPHILE_PORT")
-		graphileAddress string        = os.Getenv("GRAPHILE_ADDRESS")
+		defaultTimeout time.Duration = 10 * time.Second
+		graphileUrl                  = os.Getenv("GRAPHILE_URL")
 	)
-	if graphilePort == "" {
-		graphilePort = "5001"
+	const defaultGraphileUrl = "http://localhost:5001"
+
+	if graphileUrl == "" {
+		graphileUrl = defaultGraphileUrl
 	}
-	if graphileAddress == "" {
-		graphileAddress = "localhost"
+
+	// Check if the URL is valid
+	if _, err := url.Parse(graphileUrl); err != nil {
+		graphileUrl = defaultGraphileUrl
 	}
+
 	return NonodoOpts{
 		AnvilAddress:        devnet.AnvilDefaultAddress,
 		AnvilPort:           devnet.AnvilDefaultPort,
@@ -125,8 +129,7 @@ func NewNonodoOpts() NonodoOpts {
 		Namespace:           DefaultNamespace,
 		TimeoutInspect:      defaultTimeout,
 		TimeoutAdvance:      defaultTimeout,
-		GraphileAddress:     graphileAddress,
-		GraphilePort:        graphilePort,
+		GraphileUrl:         graphileUrl,
 		GraphileDisableSync: false,
 	}
 }
@@ -164,7 +167,13 @@ func NewSupervisorHLGraphQL(opts NonodoOpts) supervisor.SupervisorWorker {
 	if opts.NodeVersion == "v1" {
 		adapter = reader.NewAdapterV1(db, convenienceService)
 	} else {
-		httpClient := container.GetGraphileClient(opts.GraphileAddress, opts.GraphilePort, opts.LoadTestMode)
+		graphileUrl, err := url.Parse(opts.GraphileUrl)
+		if err != nil {
+			slog.Error("Error parsing Graphile URL", "error", err)
+			panic(err)
+		}
+
+		httpClient := container.GetGraphileClient(*graphileUrl, opts.LoadTestMode)
 		inputBlobAdapter := reader.InputBlobAdapter{}
 		adapter = reader.NewAdapterV2(convenienceService, httpClient, inputBlobAdapter)
 	}
@@ -189,7 +198,13 @@ func NewSupervisorHLGraphQL(opts NonodoOpts) supervisor.SupervisorWorker {
 		var synchronizer supervisor.Worker
 
 		if opts.NodeVersion == "v2" {
-			synchronizer = container.GetGraphileSynchronizer(opts.GraphileAddress, opts.GraphilePort, opts.LoadTestMode)
+			graphileUrl, err := url.Parse(opts.GraphileUrl)
+			if err != nil {
+				slog.Error("Error parsing Graphile URL", "error", err)
+				panic(err)
+			}
+
+			synchronizer = container.GetGraphileSynchronizer(*graphileUrl, opts.LoadTestMode)
 		} else {
 			synchronizer = container.GetGraphQLSynchronizer()
 		}

--- a/internal/nonodo/nonodo.go
+++ b/internal/nonodo/nonodo.go
@@ -88,10 +88,16 @@ type NonodoOpts struct {
 
 // Create the options struct with default values.
 func NewNonodoOpts() NonodoOpts {
-	var defaultTimeout time.Duration = 10 * time.Second
-	var graphilePort string = os.Getenv("GRAPHILE_PORT")
+	var (
+		defaultTimeout  time.Duration = 10 * time.Second
+		graphilePort    string        = os.Getenv("GRAPHILE_PORT")
+		graphileAddress string        = os.Getenv("GRAPHILE_ADDRESS")
+	)
 	if graphilePort == "" {
 		graphilePort = "5001"
+	}
+	if graphileAddress == "" {
+		graphileAddress = "localhost"
 	}
 	return NonodoOpts{
 		AnvilAddress:        devnet.AnvilDefaultAddress,
@@ -119,7 +125,7 @@ func NewNonodoOpts() NonodoOpts {
 		Namespace:           DefaultNamespace,
 		TimeoutInspect:      defaultTimeout,
 		TimeoutAdvance:      defaultTimeout,
-		GraphileAddress:     "localhost",
+		GraphileAddress:     graphileAddress,
 		GraphilePort:        graphilePort,
 		GraphileDisableSync: false,
 	}

--- a/main.go
+++ b/main.go
@@ -427,11 +427,7 @@ func init() {
 	cmd.Flags().BoolVar(&opts.GraphileDisableSync, "graphile-disable-sync", opts.GraphileDisableSync,
 		"If set, disable graphile synchronization")
 
-	cmd.Flags().StringVar(&opts.GraphileAddress, "graphile-address", opts.GraphileAddress,
-		"Address used to connect to Graphile")
-
-	cmd.Flags().StringVar(&opts.GraphilePort, "graphile-port", opts.GraphilePort,
-		"Port used to connect to Graphile")
+	cmd.Flags().StringVar(&opts.GraphileUrl, "graphile-url", opts.GraphileUrl, "URL used to connect to Graphile")
 }
 
 func run(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
The code changes update the Graphile configuration to use environment variables for specifying the host and port.