### PR TITLE
Update rollups contracts to version 2.0.0-rc.8

### DIFF
--- a/internal/contracts/generate/main.go
+++ b/internal/contracts/generate/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	celestiaUrl         = "https://raw.githubusercontent.com/miltonjonat/rollups-celestia/main/onchain/deployments/sepolia/CelestiaRelay.json"
-	rollupsContractsUrl = "https://registry.npmjs.org/@cartesi/rollups/-/rollups-2.0.0-rc.6.tgz"
+	rollupsContractsUrl = "https://registry.npmjs.org/@cartesi/rollups/-/rollups-2.0.0-rc.8.tgz"
 	baseContractsPath   = "package/export/artifacts/contracts/"
 	bindingPkg          = "contracts"
 )


### PR DESCRIPTION
This pull request updates the rollups contracts to version 2.0.0-rc.8.