### PR TITLE
Pin version openapi to 0.9.0 instead permalink and bump sdk/cli

### DIFF
--- a/api/generate/main.go
+++ b/api/generate/main.go
@@ -24,7 +24,6 @@ func getYAML(v2 string) ([]byte, error) {
 	}
 
 	data, err := io.ReadAll(resp.Body)
-
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read OpenAPI from %s: %s", v2, err.Error())
 	}
@@ -35,7 +34,7 @@ func getYAML(v2 string) ([]byte, error) {
 	// Because oapi-codegen will generate the same name for
 	// both GioResponse from schema and GioResponse from client
 	// https://github.com/deepmap/oapi-codegen/issues/386
-	var str = string(data)
+	str := string(data)
 	str = strings.ReplaceAll(str, "GioResponse", "GioResponseRollup")
 	return []byte(str), nil
 }
@@ -48,8 +47,7 @@ func checkErr(context string, err error) {
 
 func main() {
 	commons.ConfigureLog(slog.LevelDebug)
-	// v2URL := "https://raw.githubusercontent.com/cartesi/openapi-interfaces/v0.8.0/rollup.yaml"
-	v2URL := "https://raw.githubusercontent.com/cartesi/openapi-interfaces/b0209b2203c823a1648330236a7a211d720d48bd/rollup.yaml"
+	v2URL := "https://raw.githubusercontent.com/cartesi/openapi-interfaces/v0.9.0/rollup.yaml"
 	inspectURL := "https://raw.githubusercontent.com/cartesi/rollups-node/v1.4.0/api/openapi/inspect.yaml"
 
 	v2, wrong := getYAML(v2URL)

--- a/internal/devnet/gen-devnet-state/main.go
+++ b/internal/devnet/gen-devnet-state/main.go
@@ -30,7 +30,7 @@ func main() {
 	// https://github.com/cartesi/cli/pkgs/container/sdk
 	// update me when the image is updated
 	slog.Info("Creating temporary container")
-	run("docker", "create", "--name", "temp-devnet", "ghcr.io/cartesi/sdk:0.8.0")
+	run("docker", "create", "--name", "temp-devnet", "ghcr.io/cartesi/sdk:0.10.0")
 	slog.Info("Copying the state file")
 	defer func() {
 		run("docker", "rm", "temp-devnet")


### PR DESCRIPTION
For instance, the SDK does nothing because we deploy our contracts with the new versions to the Anvil state. Also, change the permalink to the 0.9.0 tag.