### PR TITLE
Refactor inputBoxIndex to int64

### DIFF
--- a/internal/convenience/decoder/decoder.go
+++ b/internal/convenience/decoder/decoder.go
@@ -120,7 +120,7 @@ func (o *OutputDecoder) HandleInput(
 		AppContract:            convertedInput.AppContract,
 		EspressoBlockNumber:    -1,
 		EspressoBlockTimestamp: time.Unix(-1, 0),
-		InputBoxIndex:          int(convertedInput.InputBoxIndex),
+		InputBoxIndex:          convertedInput.InputBoxIndex,
 	})
 	return err
 }

--- a/internal/convenience/model/type.go
+++ b/internal/convenience/model/type.go
@@ -107,7 +107,7 @@ type AdvanceInput struct {
 	Exception              []byte
 	EspressoBlockNumber    int       `db:"espresso_block_number"`
 	EspressoBlockTimestamp time.Time `db:"espresso_block_timestamp"`
-	InputBoxIndex          int       `db:"input_box_index"`
+	InputBoxIndex          int64     `db:"input_box_index"`
 }
 
 type ConvertedInput struct {

--- a/internal/convenience/repository/input_repository.go
+++ b/internal/convenience/repository/input_repository.go
@@ -415,7 +415,7 @@ func parseRowInput(row inputRow) model.AdvanceInput {
 		AppContract:            common.HexToAddress(row.AppContract),
 		EspressoBlockNumber:    row.EspressoBlockNumber,
 		EspressoBlockTimestamp: time.UnixMilli(int64(row.EspressoBlockTimestamp)),
-		InputBoxIndex:          row.InputBoxIndex,
+		InputBoxIndex:          int64(row.InputBoxIndex),
 	}
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -75,7 +75,7 @@ func (m *NonodoModel) AddAdvanceInput(
 		BlockNumber:            blockNumber,
 		EspressoBlockNumber:    -1,
 		EspressoBlockTimestamp: time.Unix(-1, 0),
-		InputBoxIndex:          inputBoxIndex,
+		InputBoxIndex:          int64(inputBoxIndex),
 	}
 
 	_, err = m.inputRepository.Create(ctx, input)

--- a/internal/reader/graph/generated.go
+++ b/internal/reader/graph/generated.go
@@ -2442,9 +2442,9 @@ func (ec *executionContext) _Input_inputBoxIndex(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(int64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Input_inputBoxIndex(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -9419,6 +9419,21 @@ func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}
 
 func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
 	res := graphql.MarshalInt(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2int64(ctx context.Context, v interface{}) (int64, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.SelectionSet, v int64) graphql.Marshaler {
+	res := graphql.MarshalInt64(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/internal/reader/input_blob_adapter.go
+++ b/internal/reader/input_blob_adapter.go
@@ -45,7 +45,7 @@ func (i *InputBlobAdapter) Adapt(node struct {
 		Timestamp:     values[4].(*big.Int).String(),
 		BlockNumber:   values[3].(*big.Int).String(),
 		Payload:       string(values[7].([]uint8)),
-		InputBoxIndex: values[6].(int),
+		InputBoxIndex: values[6].(*big.Int).Int64(),
 	}, nil
 }
 

--- a/internal/reader/model/types.go
+++ b/internal/reader/model/types.go
@@ -23,7 +23,7 @@ type Input struct {
 	// Number of the Espresso block in which the input was recorded
 	EspressoBlockNumber string `json:"espressoBlockNumber"`
 	// Input index in the Inpux Box
-	InputBoxIndex int `json:"inputBoxIndex"`
+	InputBoxIndex int64 `json:"inputBoxIndex"`
 	// Input payload in Ethereum hex binary format, starting with '0x'
 }
 


### PR DESCRIPTION
This pull request refactors the `inputBoxIndex` field from `int` to `int64` in multiple files. The changes ensure consistency and compatibility with the data type used in other parts of the codebase from ABI contract.