### PR TITLE
filter inputs according to type

### DIFF
--- a/api/reader.graphql
+++ b/api/reader.graphql
@@ -172,7 +172,7 @@ input InputFilter {
   "Filter only inputs with the message sender"
   msgSender: String
 
-  "Filter only inputs from 'Espresso' or 'L1'"
+  "Filter only inputs from 'inputbox' or 'espresso'"
   type: String
 }
 

--- a/api/reader.graphql
+++ b/api/reader.graphql
@@ -171,6 +171,9 @@ input InputFilter {
 
   "Filter only inputs with the message sender"
   msgSender: String
+
+  "Filter only inputs from 'Espresso' or 'L1'"
+  type: String
 }
 
 scalar BigInt

--- a/internal/convenience/repository/input_repository.go
+++ b/internal/convenience/repository/input_repository.go
@@ -394,6 +394,18 @@ func transformToInputQuery(
 			} else {
 				return "", nil, 0, fmt.Errorf("operation not implemented")
 			}
+		} else if *filter.Field == "InputBoxIndex" {
+			if filter.Ne != nil {
+				where = append(where, fmt.Sprintf("input_box_index <> $%d ", count))
+				args = append(args, *filter.Ne)
+				count += 1
+			} else if filter.Eq != nil {
+				where = append(where, fmt.Sprintf("input_box_index = $%d ", count))
+				args = append(args, *filter.Eq)
+				count += 1
+			} else {
+				return "", nil, 0, fmt.Errorf("operation not implemented")
+			}
 		} else {
 			return "", nil, 0, fmt.Errorf("unexpected field %s", *filter.Field)
 		}

--- a/internal/reader/adapter_v1.go
+++ b/internal/reader/adapter_v1.go
@@ -264,6 +264,21 @@ func (a AdapterV1) GetInputs(
 				Eq:    where.MsgSender,
 			})
 		}
+		if where.Type != nil {
+			L1Field := "InputBoxIndex"
+			defaultStr := "-1"
+			if *where.Type == "L1" {
+				filters = append(filters, &cModel.ConvenienceFilter{
+					Field: &L1Field,
+					Ne:    &defaultStr,
+				})
+			} else if *where.Type == "Espresso" {
+				filters = append(filters, &cModel.ConvenienceFilter{
+					Field: &L1Field,
+					Eq:    &defaultStr,
+				})
+			}
+		}
 	}
 	inputs, err := a.inputRepository.FindAll(
 		ctx, first, last, after, before, filters,

--- a/internal/reader/adapter_v1.go
+++ b/internal/reader/adapter_v1.go
@@ -265,16 +265,16 @@ func (a AdapterV1) GetInputs(
 			})
 		}
 		if where.Type != nil {
-			L1Field := "InputBoxIndex"
+			inputboxField := "InputBoxIndex"
 			defaultStr := "-1"
-			if *where.Type == "L1" {
+			if *where.Type == "inputbox" {
 				filters = append(filters, &cModel.ConvenienceFilter{
-					Field: &L1Field,
+					Field: &inputboxField,
 					Ne:    &defaultStr,
 				})
-			} else if *where.Type == "Espresso" {
+			} else if *where.Type == "espresso" {
 				filters = append(filters, &cModel.ConvenienceFilter{
-					Field: &L1Field,
+					Field: &inputboxField,
 					Eq:    &defaultStr,
 				})
 			}

--- a/internal/reader/graph/generated.go
+++ b/internal/reader/graph/generated.go
@@ -1067,6 +1067,9 @@ input InputFilter {
 
   "Filter only inputs with the message sender"
   msgSender: String
+
+  "Filter only inputs from 'Espresso' or 'L1'"
+  type: String
 }
 
 scalar BigInt
@@ -7548,7 +7551,7 @@ func (ec *executionContext) unmarshalInputInputFilter(ctx context.Context, obj i
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"indexLowerThan", "indexGreaterThan", "msgSender"}
+	fieldsInOrder := [...]string{"indexLowerThan", "indexGreaterThan", "msgSender", "type"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -7576,6 +7579,13 @@ func (ec *executionContext) unmarshalInputInputFilter(ctx context.Context, obj i
 				return it, err
 			}
 			it.MsgSender = data
+		case "type":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Type = data
 		}
 	}
 

--- a/internal/reader/graph/generated.go
+++ b/internal/reader/graph/generated.go
@@ -1068,7 +1068,7 @@ input InputFilter {
   "Filter only inputs with the message sender"
   msgSender: String
 
-  "Filter only inputs from 'Espresso' or 'L1'"
+  "Filter only inputs from 'inputbox' or 'espresso'"
   type: String
 }
 

--- a/internal/reader/model/generated.go
+++ b/internal/reader/model/generated.go
@@ -39,7 +39,7 @@ type InputFilter struct {
 	IndexGreaterThan *int `json:"indexGreaterThan,omitempty"`
 	// Filter only inputs with the message sender
 	MsgSender *string `json:"msgSender,omitempty"`
-	// Filter only inputs from 'Espresso' or 'L1'
+	// Filter only inputs from 'inputbox' or 'espresso'
 	Type *string `json:"type,omitempty"`
 }
 

--- a/internal/reader/model/generated.go
+++ b/internal/reader/model/generated.go
@@ -39,6 +39,8 @@ type InputFilter struct {
 	IndexGreaterThan *int `json:"indexGreaterThan,omitempty"`
 	// Filter only inputs with the message sender
 	MsgSender *string `json:"msgSender,omitempty"`
+	// Filter only inputs from 'Espresso' or 'L1'
+	Type *string `json:"type,omitempty"`
 }
 
 // Page metadata for the cursor-based Connection pagination pattern


### PR DESCRIPTION
Now we can filter inputs according to whether it's "L1" or "Espresso". For example,
```
{inputs(where: {msgSender: "0x590F92fEa8df163fFF2d7Df266364De7CE8F9E16" type: "L1"}) 
  {
                totalCount
}}
```