### PR TITLE
Add timeout flag for worker

### DIFF
--- a/internal/nonodo/nonodo.go
+++ b/internal/nonodo/nonodo.go
@@ -82,6 +82,7 @@ type NonodoOpts struct {
 
 	TimeoutInspect time.Duration
 	TimeoutAdvance time.Duration
+	TimeoutWorker  time.Duration
 
 	GraphileUrl         string
 	GraphileDisableSync bool
@@ -132,6 +133,7 @@ func NewNonodoOpts() NonodoOpts {
 		Namespace:           DefaultNamespace,
 		TimeoutInspect:      defaultTimeout,
 		TimeoutAdvance:      defaultTimeout,
+		TimeoutWorker:       supervisor.DefaultSupervisorTimeout,
 		GraphileUrl:         graphileUrl,
 		GraphileDisableSync: false,
 		Salsa:               false,
@@ -141,7 +143,7 @@ func NewNonodoOpts() NonodoOpts {
 
 func NewSupervisorHLGraphQL(opts NonodoOpts) supervisor.SupervisorWorker {
 	var w supervisor.SupervisorWorker
-
+	w.Timeout = opts.TimeoutWorker
 	var db *sqlx.DB
 
 	if opts.DbImplementation == "postgres" {
@@ -279,6 +281,7 @@ func handleAnvilInstallation() (string, error) {
 // Create the nonodo supervisor.
 func NewSupervisor(opts NonodoOpts) supervisor.SupervisorWorker {
 	var w supervisor.SupervisorWorker
+	w.Timeout = opts.TimeoutWorker
 	db := sqlx.MustConnect("sqlite3", opts.SqliteFile)
 	container := convenience.NewContainer(*db)
 	decoder := container.GetOutputDecoder()

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -35,6 +35,9 @@ func (w SupervisorWorker) Start(ctx context.Context, ready chan<- struct{}) erro
 	timeout := w.Timeout
 	if timeout == 0 {
 		timeout = DefaultSupervisorTimeout
+		slog.Debug("supervisor: using default timeout", "timeout", timeout)
+	} else {
+		slog.Debug("supervisor: using custom timeout", "timeout", timeout)
 	}
 
 	// Start workers

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Timeout when waiting for workers to finish.
-const DefaultSupervisorTimeout = time.Second * 5
+const DefaultSupervisorTimeout = time.Second * 15
 
 // Start the workers in order, waiting for each one to be ready before starting the next one.
 // When a worker exits, send a cancel signal to all of them and wait for them to finish.

--- a/main.go
+++ b/main.go
@@ -391,6 +391,7 @@ func init() {
 		"Set the sequencer (inputbox[default] or espresso)")
 	cmd.Flags().Uint64Var(&opts.Namespace, "namespace", opts.Namespace,
 		"Set the namespace for espresso")
+	cmd.Flags().DurationVar(&opts.TimeoutWorker, "timeout-worker", opts.TimeoutWorker, "Timeout for workers. Example: nonodo --timeout-worker 30s")
 	cmd.Flags().DurationVar(&opts.TimeoutInspect, "sm-deadline-inspect-state", opts.TimeoutInspect, "Timeout for inspect requests. Example: nonodo --sm-deadline-inspect-state 30s")
 	cmd.Flags().DurationVar(&opts.TimeoutAdvance, "sm-deadline-advance-state", opts.TimeoutAdvance, "Timeout for advance requests. Example: nonodo --sm-deadline-advance-state 30s")
 


### PR DESCRIPTION
This pull request adds a new flag `--timeout-worker` to specify the timeout duration for workers. The default timeout is set to the value of `supervisor.DefaultSupervisorTimeout`.