### PR TITLE
Update Anvil installation and handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           go-version: "1.21"
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ env.ANVIL_TAG }}
+
       - name: Lint
         uses: golangci/golangci-lint-action@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,11 +23,6 @@ jobs:
         with:
           go-version: "1.21"
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: ${{ env.ANVIL_TAG }}
-
       - name: Lint
         uses: golangci/golangci-lint-action@v5
         with:

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ NoNodo is a valuable development workflow help, but there are some [caveats](#ca
 
 ## Installation
 
-### Pre-requisites
+### Battery-included
 
 NoNodo uses the Anvil as the underlying Ethereum node.
-To install Anvil, read the instructions on the [Foundry book](https://book.getfoundry.sh/getting-started/installation).
+For the current version, NoNodo provides a built-in anvil, *we don't use the system foundry*.
 
 ### Binaries
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ NoNodo is a valuable development workflow help, but there are some [caveats](#ca
 ### Battery-included
 
 NoNodo uses the Anvil as the underlying Ethereum node.
-For the current version, NoNodo provides a built-in anvil, *we don't use the system foundry*.
+For the current version, NoNodo provides a built-in anvil (from Foundry), *we don't use the system foundry*.
+You can change the version by setting the `ANVIL_TAG` environment variable to a specific tag before executing NoNodo:
+
+```bash
+export ANVIL_TAG=nightly-2cdbfaca634b284084d0f86357623aef7a0d2ce3
+```
 
 ### Binaries
 

--- a/internal/commons/handle_release.go
+++ b/internal/commons/handle_release.go
@@ -24,6 +24,7 @@ type ReleaseAsset struct {
 	Filename string `json:"filename"`
 	Url      string `json:"url"`
 	Path     string `json:"path"`
+	NodeId   string `json:"node_id"`
 }
 
 // Interface for handle libraries on GitHub
@@ -117,10 +118,15 @@ func (a AnvilRelease) TryLoadConfig() (*AnvilConfig, error) {
 	root := filepath.Join(os.TempDir())
 	file := filepath.Join(root, a.ConfigFilename)
 	if _, err := os.Stat(file); err == nil {
-		slog.Debug("Anvil config already exists", "path", file)
-		return LoadAnvilConfig(file)
+		slog.Debug("anvil: config already exists", "path", file)
+		cfg, err := LoadAnvilConfig(file)
+		if err == nil && cfg.AssetAnvil.Tag == "nightly" {
+			slog.Debug("anvil: config is nightly, download new...", "tag", cfg.AssetAnvil.Tag)
+			return nil, nil
+		}
+		return cfg, err
 	}
-	slog.Debug("Anvil config not found", "path", file)
+	slog.Debug("anvil: config not found", "path", file)
 
 	return nil, nil
 }
@@ -140,7 +146,7 @@ func (a AnvilRelease) FormatNameRelease(_, goos, goarch, _ string) string {
 // PlatformCompatible implements HandleRelease.
 func (a AnvilRelease) PlatformCompatible() (string, error) {
 	// Check if the platform is compatible with Anvil
-	slog.Debug("System", "GOARCH:", runtime.GOARCH, "GOOS:", runtime.GOOS)
+	slog.Debug("anvil: System", "GOARCH:", runtime.GOARCH, "GOOS:", runtime.GOOS)
 	goarch := runtime.GOARCH
 	goos := runtime.GOOS
 
@@ -158,7 +164,7 @@ func (a *AnvilRelease) ExtractAsset(archive []byte, filename string, destDir str
 	} else if strings.HasSuffix(filename, ".tar.gz") {
 		return ExtractTarGz(archive, destDir)
 	} else {
-		return fmt.Errorf("format unsupported: %s", filename)
+		return fmt.Errorf("anvil: format unsupported: %s", filename)
 	}
 }
 
@@ -177,13 +183,13 @@ func (a *AnvilRelease) DownloadAsset(ctx context.Context, release *ReleaseAsset)
 	}
 
 	anvilExec := filepath.Join(root, filename)
-	slog.Debug("Anvil executable", "path", anvilExec)
+	slog.Debug("anvil: executable", "path", anvilExec)
 	if _, err := os.Stat(anvilExec); err == nil {
-		slog.Debug("Anvil already downloaded", "path", anvilExec)
+		slog.Debug("anvil: executable already downloaded", "path", anvilExec)
 		return anvilExec, nil
 	}
 
-	slog.Debug("Downloading anvil", "id", release.AssetId, "to", root)
+	slog.Debug("anvil: downloading", "id", release.AssetId, "to", root)
 
 	rc, redirect, err := a.Client.Repositories.DownloadReleaseAsset(ctx, a.Namespace, a.Repository, release.AssetId)
 	if err != nil {
@@ -191,7 +197,7 @@ func (a *AnvilRelease) DownloadAsset(ctx context.Context, release *ReleaseAsset)
 	}
 
 	if redirect != "" {
-		slog.Debug("Redirect", "url", redirect)
+		slog.Debug("anvil: redirect asset", "url", redirect)
 
 		res, err := http.Get(redirect)
 		if err != nil {
@@ -207,7 +213,7 @@ func (a *AnvilRelease) DownloadAsset(ctx context.Context, release *ReleaseAsset)
 		return "", fmt.Errorf("anvil: failed to read asset %s", err.Error())
 	}
 
-	slog.Debug("Downloaded compacted file anvil")
+	slog.Debug("anvil: downloaded compacted file anvil")
 
 	err = a.ExtractAsset(data, release.Filename, root)
 	if err != nil {
@@ -215,6 +221,13 @@ func (a *AnvilRelease) DownloadAsset(ctx context.Context, release *ReleaseAsset)
 	}
 
 	release.Path = root
+
+	// Save path on config
+	cfg := NewAnvilConfig(*release)
+	err = a.SaveConfigOnDefaultLocation(cfg)
+	if err != nil {
+		return "", err
+	}
 
 	return anvilExec, nil
 }
@@ -226,29 +239,41 @@ func (a *AnvilRelease) ListRelease(ctx context.Context) ([]ReleaseAsset, error) 
 
 // GetLatestReleaseCompatible implements HandleRelease.
 func (a *AnvilRelease) GetLatestReleaseCompatible(ctx context.Context) (*ReleaseAsset, error) {
-	p, err := a.PlatformCompatible()
+	platform, err := a.PlatformCompatible()
 	if err != nil {
 		return nil, err
 	}
-	slog.Debug("PlatformCompatible", "p", p)
+	slog.Debug("anvil:", "platform", platform)
 
 	config, err := a.TryLoadConfig()
 	if err != nil {
 		return nil, err
 	}
 
+	anvilTag, fromEnv := os.LookupEnv("ANVIL_TAG")
+
+	if !fromEnv {
+		// Same behavior of Foundryup
+		anvilTag = "nightly"
+	}
+	slog.Debug("anvil: using", "tag", anvilTag, "fromEnv", fromEnv)
+
 	var target *ReleaseAsset = nil
 
 	// Get release asset from config
 	if config != nil {
-		target = &config.AssetAnvil
-		return target, nil
-	}
+		// Show config
+		cfgStr, err := json.Marshal(config)
+		if err != nil {
+			slog.Debug("anvil:", "config", config)
+		} else {
+			slog.Debug("anvil:", "config", string(cfgStr))
+		}
 
-	anvilTag, haveTag := os.LookupEnv("ANVIL_TAG")
-
-	if !haveTag {
-		anvilTag = ""
+		if config.AssetAnvil.Tag == anvilTag {
+			target = &config.AssetAnvil
+			return target, nil
+		}
 	}
 
 	assets, err := GetAssetsFromLastReleaseGitHub(ctx, a.Client, a.Namespace, a.Repository, anvilTag)
@@ -256,14 +281,20 @@ func (a *AnvilRelease) GetLatestReleaseCompatible(ctx context.Context) (*Release
 		return nil, err
 	}
 
-	for _, a := range assets {
-		if a.Filename == p {
-			target = &a
+	for _, anvilAssets := range assets {
+		if anvilAssets.Filename == platform {
+			target = &anvilAssets
 			break
 		}
 	}
 
-	slog.Debug("PlatformCompatible", "target", target)
+	targetStr, err := json.Marshal(target)
+	if err != nil {
+		slog.Debug("anvil:", "target", target)
+	} else {
+		slog.Debug("anvil:", "target", string(targetStr))
+	}
+
 	if target != nil {
 		c := NewAnvilConfig(*target)
 		err := a.SaveConfigOnDefaultLocation(c)

--- a/internal/commons/handle_release.go
+++ b/internal/commons/handle_release.go
@@ -24,7 +24,6 @@ type ReleaseAsset struct {
 	Filename string `json:"filename"`
 	Url      string `json:"url"`
 	Path     string `json:"path"`
-	NodeId   string `json:"node_id"`
 }
 
 // Interface for handle libraries on GitHub

--- a/internal/commons/utils.go
+++ b/internal/commons/utils.go
@@ -54,7 +54,7 @@ func ExtractTarGz(archive []byte, destDir string) error {
 				return err
 			}
 		default:
-			return fmt.Errorf("Unsupported type: %v", header.Typeflag)
+			return fmt.Errorf("extract: unsupported type: %v", header.Typeflag)
 		}
 	}
 	return nil
@@ -104,47 +104,38 @@ func ExtractZip(archive []byte, destDir string) error {
 // Get assets of latest release or prerelease from GitHub
 func GetAssetsFromLastReleaseGitHub(ctx context.Context, client *github.Client, namespace, repository string, tag string) ([]ReleaseAsset, error) {
 	// List the tags of the GitHub repository
-	slog.Debug("Listing tags for", namespace, repository)
+	slog.Debug("github: listing tags for", "namespace", namespace, "repository", repository)
+
+	releases := make([]*github.RepositoryRelease, 0)
+	releaseAssets := make([]ReleaseAsset, 0)
 
 	if tag != "" {
 		release, _, err := client.Repositories.GetReleaseByTag(ctx, namespace, repository, tag)
 
 		if err != nil {
-			return nil, fmt.Errorf("%s(%s): failed to get release %s", namespace, repository, err.Error())
+			return nil, fmt.Errorf("github: %s(%s): failed to get release %s", namespace, repository, err.Error())
 		}
 
-		ra := make([]ReleaseAsset, 0)
+		releases = append(releases, release)
+	} else {
+		listReleases, _, err := client.Repositories.ListReleases(ctx, namespace, repository, &github.ListOptions{
+			PerPage: 1,
+		})
 
-		for _, a := range release.Assets {
-			slog.Debug("Asset", "tag", release.GetTagName(), "name", a.GetName(), "url", a.GetBrowserDownloadURL())
-			ra = append(ra, ReleaseAsset{
-				Tag:      release.GetTagName(),
-				AssetId:  a.GetID(),
-				Filename: a.GetName(),
-				Url:      a.GetBrowserDownloadURL(),
-			})
+		// For stable releases
+		// release, _, err := client.Repositories.GetLatestRelease(ctx, namespace, repository)
+
+		if err != nil {
+			return nil, fmt.Errorf("github: %s(%s): failed to list releases %s", namespace, repository, err.Error())
 		}
 
-		return ra, nil
+		releases = append(releases, listReleases...)
 	}
-
-	releases, _, err := client.Repositories.ListReleases(ctx, namespace, repository, &github.ListOptions{
-		PerPage: 1,
-	})
-
-	// For stable releases
-	// release, _, err := client.Repositories.GetLatestRelease(ctx, namespace, repository)
-
-	if err != nil {
-		return nil, fmt.Errorf("%s(%s): failed to list releases %s", namespace, repository, err.Error())
-	}
-
-	ra := make([]ReleaseAsset, 0)
 
 	for _, r := range releases {
 		for _, a := range r.Assets {
-			slog.Debug("Asset", "tag", r.GetTagName(), "name", a.GetName(), "url", a.GetBrowserDownloadURL())
-			ra = append(ra, ReleaseAsset{
+			slog.Debug("github: asset", "tag", r.GetTagName(), "name", a.GetName(), "url", a.GetBrowserDownloadURL())
+			releaseAssets = append(releaseAssets, ReleaseAsset{
 				Tag:      r.GetTagName(),
 				AssetId:  a.GetID(),
 				Filename: a.GetName(),
@@ -153,5 +144,5 @@ func GetAssetsFromLastReleaseGitHub(ctx context.Context, client *github.Client, 
 		}
 	}
 
-	return ra, nil
+	return releaseAssets, nil
 }

--- a/internal/devnet/anvil.go
+++ b/internal/devnet/anvil.go
@@ -57,11 +57,6 @@ func (w AnvilWorker) String() string {
 	return anvilCommand
 }
 
-func IsAnvilInstalled() bool {
-	_, err := exec.LookPath(anvilCommand)
-	return err == nil
-}
-
 func InstallAnvil(ctx context.Context) (string, error) {
 	// Try to install anvil
 	anvilClient := commons.NewAnvilRelease()
@@ -89,28 +84,19 @@ func GetAnvilVersion(anvilExec string) (string, error) {
 	return anvilVersion, nil
 }
 
+// For while, we dont check if anvil is already installed.
+// We always install anvil.
 func CheckAnvilAndInstall(ctx context.Context) (string, error) {
-	if !IsAnvilInstalled() {
-		slog.Debug("anvil: anvil is not installed")
-		location, err := InstallAnvil(ctx)
-		if err != nil {
-			return "", fmt.Errorf("anvil: failed to install %w", err)
-		}
-		slog.Debug("anvil: installed anvil", "location", location)
-		anvilVersion, err := GetAnvilVersion(location)
-		if err != nil {
-			return "", err
-		}
-		slog.Debug("anvil: installed anvil", "location", location, "version", anvilVersion)
-		return location, nil
+	location, err := InstallAnvil(ctx)
+	if err != nil {
+		return "", fmt.Errorf("anvil: failed to install %w", err)
 	}
-
-	anvilVersion, err := GetAnvilVersion(anvilCommand)
+	anvilVersion, err := GetAnvilVersion(location)
 	if err != nil {
 		return "", err
 	}
-	slog.Debug("anvil: anvil is installed", "version", anvilVersion)
-	return anvilCommand, nil
+	slog.Debug("anvil: installed anvil", "location", location, "version", anvilVersion)
+	return location, nil
 }
 
 func ShowAddresses() {


### PR DESCRIPTION
This pull request includes changes to the Anvil installation and handling process. It updates the installation instructions to use the built-in Anvil instead of the system foundry. It also improves the handling of Anvil configurations and assets, including downloading and extracting assets, saving paths on the config, and checking for the latest compatible release. Additionally, it removes the check for an existing Anvil installation and always installs Anvil.