### PR TITLE
fix: default sequencer to resolve new inputs /finish

### DIFF
--- a/internal/nonodo/nonodo.go
+++ b/internal/nonodo/nonodo.go
@@ -522,6 +522,7 @@ func NewSupervisor(opts NonodoOpts) supervisor.SupervisorWorker {
 				paioLocation,
 				opts.ApplicationAddress,
 			))
+			sequencer = model.NewInputBoxSequencer(modelInstance)
 		}
 	} else {
 		sequencer = model.NewInputBoxSequencer(modelInstance)


### PR DESCRIPTION
```bash
INFO:__main__:HTTP rollup_server url is http://10.0.2.2:5004
INFO:__main__:Sending finish
INFO:__main__:Received finish status 500
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 971, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/mnt/dapp.py", line 36, in <module>
    rollup_request = response.json()
  File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 975, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

Halted with payload: 1
Cycles: 2949106528
```
João Garcia
Just checked. @fabio.oshiro and @sandhilt  it seems brunodo 2.11.x has this error when starting a dApp that already have inputs in the queue (might be something else, but with brunodo 2.10.x it is working fine)

this error only happens with the avail flag