### PR TITLE
fix: filter transactions to other dapp

### DIFF
--- a/internal/sequencers/espresso/espresso_listener.go
+++ b/internal/sequencers/espresso/espresso_listener.go
@@ -184,6 +184,17 @@ func (e EspressoListener) watchNewTransactions(ctx context.Context) error {
 					return fmt.Errorf("error converting nonce: %T", nonceField)
 				}
 
+				app, ok := typedData.Message["app"].(string)
+				if !ok {
+					return fmt.Errorf("message app address type assertion error")
+				}
+				appContract := common.HexToAddress(app)
+
+				if appContract.Hex() != e.InputterWorker.ApplicationAddress.Hex() {
+					slog.Debug("Espresso: ignoring transaction for other app", "txApp", appContract.Hex(), "expectedApp", e.InputterWorker.ApplicationAddress.Hex())
+					continue
+				}
+
 				payload, ok := typedData.Message["data"].(string)
 				if !ok {
 					return fmt.Errorf("message data type assertion error")


### PR DESCRIPTION
```bash
go build . && ./nonodo --http-rollups-port=5004 --http-port=8081 \
--sqlite-file=database.sqlite3 \
--from-l1-block=7019226 \
--rpc-url=wss://sepolia.gateway.tenderly.co \
--contracts-application-address=0xb6F3dc1E483704bF2659835EAC568661DAa73c93 \
--sequencer=espresso \
--espresso-url=https://query.decaf.testnet.espresso.network \
--from-block=0 \
--namespace=51025 --contracts-input-box-block=6994348 --contracts-input-box-address=0x593E5BCf894D6829Dd26D0810DA7F064406aebB6 \
-d
```

Log example showing input being ignored:
```
[00:30:19.070] DBG espresso/espresso_listener.go:194 Espresso: ignoring transaction for other app txApp=0xab7528bb862fB57E8A2BCd567a2e929a0Be56a5e expectedApp=0xb6F3dc1E483704bF2659835EAC568661DAa73c93

```

Log example showing input inclusion:
```
[00:30:59.176] DBG commons/eip712.go:218 ExtractSigAndData typedDataBytes="{\"domain\":{\"chainId\":11155111,\"name\":\"Cartesi\",\"verifyingContract\":\"0x0000000000000000000000000000000000000000\",\"version\":\"0.1.0\"},\"message\":{\"app\":\"0xb6F3dc1E483704bF2659835EAC568661DAa73c93\",\"data\":\"0x20241110aa01\",\"max_gas_price\":10,\"nonce\":0},\"primaryType\":\"CartesiMessage\",\"types\":{\"CartesiMessage\":[{\"name\":\"app\",\"type\":\"address\"},{\"name\":\"nonce\",\"type\":\"uint64\"},{\"name\":\"max_gas_price\",\"type\":\"uint128\"},{\"name\":\"data\",\"type\":\"bytes\"}],\"EIP712Domain\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"version\",\"type\":\"string\"},{\"name\":\"chainId\",\"type\":\"uint256\"},{\"name\":\"verifyingContract\",\"type\":\"address\"}]}}"
[00:30:59.176] DBG commons/eip712.go:224 ExtractSigAndData typedData=0xb6F3dc1E483704bF2659835EAC568661DAa73c93
[00:30:59.177] DBG commons/eip712.go:245 ExtractSigAndData publicKeyAddress=0x0c70e9a737aa92055c8c1217bf887a65cb2292f4
[00:30:59.177] DBG espresso/espresso_listener.go:202 Espresso input msgSender=0x0c70e9a737aa92055c8c1217bf887a65cb2292f4 nonce=0 payload=0x20241110aa01
[00:30:59.177] DBG espresso/espresso_listener.go:218 TypedData typedData.Domain="{Cartesi 0.1.0 0x14003dcf4c0 0x0000000000000000000000000000000000000000 }" chainId=11155111
[00:30:59.870] DBG espresso/espresso_listener.go:318 readPrevRandao prevRandao=0x4d59590f2e9c6bcd371725f05f4da186456cb6c9bbfb8944f6ffc180d6049db2 blockNumber=638634
[00:31:00.518] DBG repository/transaction_helper.go:37 No transaction found in context
[00:31:00.518] DBG repository/sql_executor.go:19 Using ExecContext without transaction.
[00:31:00.526] INF espresso/espresso_listener.go:241 Espresso: input added payload=20241110aa01
```