### PR TITLE
Update rollups-graphql dependency version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 require (
 	github.com/aws/aws-sdk-go v1.40.45 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
-	github.com/cartesi/rollups-graphql v0.0.0-20250113201852-cc35f8b69098 // indirect
+	github.com/cartesi/rollups-graphql v0.0.0-20250121203148-743bf6dc090f // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c // indirect
 	github.com/ethereum/go-verkle v0.1.1-0.20240829091221-dffa7562dbe9 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/carlmjohnson/versioninfo v0.22.5 h1:O00sjOLUAFxYQjlN/bzYTuZiS0y6fWDQj
 github.com/carlmjohnson/versioninfo v0.22.5/go.mod h1:QT9mph3wcVfISUKd0i9sZfVrPviHuSF+cUtLjm2WSf8=
 github.com/cartesi/rollups-graphql v0.0.0-20250113201852-cc35f8b69098 h1:dmMSUi90IZaUEuAkKeXPH8z8YeWcL/PCCgUgq5cwvi4=
 github.com/cartesi/rollups-graphql v0.0.0-20250113201852-cc35f8b69098/go.mod h1:UyHNESjR+yjVl/PQDZUaJRtfC2xJ5IkuoQL+QMplPPE=
+github.com/cartesi/rollups-graphql v0.0.0-20250121203148-743bf6dc090f h1:CUMJ4EIDYRCpZ/H5QcbZQ5ZLo1MR4Sc332DEnVH/Yg4=
+github.com/cartesi/rollups-graphql v0.0.0-20250121203148-743bf6dc090f/go.mod h1:UyHNESjR+yjVl/PQDZUaJRtfC2xJ5IkuoQL+QMplPPE=
 github.com/celestiaorg/celestia-core v1.43.0-tm-v0.34.35 h1:L4GTm+JUXhB0a/nGPMq6jEqqe6THuYSQ8m2kUCtZYqw=
 github.com/celestiaorg/celestia-core v1.43.0-tm-v0.34.35/go.mod h1:bFr0lAGwaJ0mOHSBmib5/ca5pbBf1yKWGPs93Td0HPw=
 github.com/celestiaorg/celestia-openrpc v0.5.0 h1:coCflj4fRoemrCv4XrUtlXXcZ8tsYBFmVabmlm1BP20=


### PR DESCRIPTION
Update the version of the `rollups-graphql` dependency to the latest release.