### PR TITLE
Disable inspect GET request handler

### DIFF
--- a/internal/inspect/inspect.go
+++ b/internal/inspect/inspect.go
@@ -6,11 +6,9 @@ package inspect
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/calindra/nonodo/internal/model"
@@ -57,14 +55,7 @@ func (a *inspectAPI) InspectPost(c echo.Context, _ string) error {
 
 // Handle GET requests to /{payload}.
 func (a *inspectAPI) Inspect(c echo.Context, appAddress string, _ string) error {
-	toRemove := len(fmt.Sprintf("/inspect/%s/", appAddress))
-	uri := c.Request().RequestURI[toRemove:] // remove '/inspect/<app-address>'
-	payload, err := url.QueryUnescape(uri)
-	slog.Debug("/inspect", "payload", payload)
-	if err != nil {
-		return c.String(http.StatusBadRequest, err.Error())
-	}
-	return a.inspect(c, []byte(payload))
+	return echo.ErrNotImplemented
 }
 
 // Send the inspect input to the model and wait until it is completed.


### PR DESCRIPTION
Disable the handling of GET requests for the inspect endpoint, returning a not implemented error instead.